### PR TITLE
fix bit timing register values

### DIFF
--- a/eXoCAN.cpp
+++ b/eXoCAN.cpp
@@ -84,7 +84,7 @@ void eXoCAN::begin(idtype addrType, int brp, bool singleWire, bool alt, bool pul
     MMIO32(mcr) |= (1 << 6) | (1 << 0); // set ABOM, init req (INRQ)
     while (periphBit(INAK) == 0)        // wait for hw ready
         ;
-    MMIO32(btr) = (3 << 20) | (12 << 16) | (brp << 0); // 125K, 12/15=80% sample pt. prescale = 15
+    MMIO32(btr) = (2 << 20) | (11 << 16) | (brp << 0); // 125K, 12/15=80% sample pt. prescale = 15
     // periphBit(ti0r, 2) = _extIDs;                      // 0 = std 11b ids, 1 = extended 29b ids
     periphBit(INRQ) = 0;                               // request init leave to Normal mode
     while (periphBit(INAK))                            // wait for hw


### PR DESCRIPTION
From the datasheet section 22.7.7 linked below, the number of clock cycles for a single bit is 1 + (TS1[3:0] + 1) + (TS2[2:0] + 1). Using the previous values of 12 and 3 for TS1 and TS2 respectively, this lead to a bit length of 18 clock cycles. With a BRP value of 15 for a prescaler of 16 to achieve a bitrate of 125kbit/s, the bit length would be 1/32 us * (18) * (16), leading to a bit length of 9 us instead of the targeted 8 us. With the values of 11 and 2 for TS1 and TS2 instead, the bit length is 1/32 us * 16 * 16 which corresponds with the correct bit length of 8us, while still having an 80% sample point.

https://www.keil.com/dd/docs/datashts/st/stm32f10xxx.pdf